### PR TITLE
Modernize Python 2 code to get ready for Python 3

### DIFF
--- a/Attention_Based_CNN (ABCNN)/dl_text/dl.py
+++ b/Attention_Based_CNN (ABCNN)/dl_text/dl.py
@@ -3,6 +3,7 @@
 ** dl-lab **
 created by :: GauravBh1010tt
 """
+from __future__ import print_function
 
 import re
 import numpy as np
@@ -65,7 +66,7 @@ def process_data(sent_l,sent_r=None,wordVec_model=None,dimx=100,dimy=100,vocab_s
     
     
     freq = FreqDist(chain(*tokenize_sent))
-    print 'found ',len(freq),' unique words'
+    print('found ',len(freq),' unique words')
     vocab = freq.most_common(vocab_size - 1)
     index_to_word = [x[0] for x in vocab]
     index_to_word.append(unk_token)
@@ -127,8 +128,8 @@ def process_data(sent_l,sent_r=None,wordVec_model=None,dimx=100,dimy=100,vocab_s
                 #print j
                 unk.append(j)
                 continue
-        print 'number of unkown words: ',len(unk)
-        print 'some unknown words ',unk[0:5]
+        print('number of unkown words: ',len(unk))
+        print('some unknown words ',unk[0:5])
     
     
     
@@ -158,7 +159,7 @@ def word2vec_embedding_layer(embedding_matrix,train=False):
     return layer
 
 def loadGloveModel(glovefile):
-    print 'Loading Glove File.....'
+    print('Loading Glove File.....')
     f = open(glovefile)
     model = {}
     for line in f:
@@ -166,8 +167,8 @@ def loadGloveModel(glovefile):
         word = splitline[0]
         embedding = np.array([float(val) for val in splitline[1:]])
         model[word] = embedding
-    print 'Loaded Word2Vec GloVe Model.....'
-    print len(model), ' words loaded.....'
+    print('Loaded Word2Vec GloVe Model.....')
+    print(len(model), ' words loaded.....')
     return model
 
 def encode_labels(labels, nclass=5):

--- a/Attention_Based_CNN (ABCNN)/dl_text/lex_sem_ft.py
+++ b/Attention_Based_CNN (ABCNN)/dl_text/lex_sem_ft.py
@@ -3,6 +3,7 @@
 ** dl-lab **
 created by :: GauravBh1010tt
 """
+from __future__ import print_function
 
 import pandas as pd
 import numpy as np

--- a/Attention_Based_CNN (ABCNN)/dl_text/metrics.py
+++ b/Attention_Based_CNN (ABCNN)/dl_text/metrics.py
@@ -11,6 +11,11 @@ from collections import defaultdict
 import scipy.stats as measures
 import numpy as np
 
+try:
+    xrange          # Python 2
+except NameError:
+    xrange = range  # Python 3
+
 ###################### CALCULATING MRR [RETURNS MRR VALUE] ######################
 
 def mrr(out, th = 10):
@@ -38,10 +43,10 @@ def map(out, th):
       if candidates[i] == "true":
         num_correct += 1
         precisions.append(num_correct/(i+1))
-    
+
     if precisions:
       avg_prec = sum(precisions)/len(precisions)
-    
+
     MAP += avg_prec
   return MAP / num_queries
 
@@ -53,7 +58,7 @@ def list2dict(lst):
 
     for i in range(len(lst)):
         interm[i+1] = lst[i]
-    
+
     for qid in interm:
         interm[qid] = sorted(interm[qid], key = itemgetter(0), reverse = True)
         val = [rel for score, rel in interm[qid]]
@@ -68,11 +73,11 @@ def list2dict(lst):
 def readfile(pred_fname):
     pred = open(pred_fname).readlines()
     pred = [line.split('\t') for line in pred]
-    
+
     ques = []
     ans = []
     i = 1
-    
+
     while i != len(pred):
         if pred[i][0] == pred[i-1][0]:
             ans.append([float(pred[i-1][-2]), pred[i-1][-1][0:-1]])
@@ -83,7 +88,7 @@ def readfile(pred_fname):
         i += 1
     ans.append([float(pred[i-1][-2]), pred[i-1][-1][0:-1]])
     ques.append(ans)
-    
+
     return ques
 
 ###################### MAP AND MRR FUNCTION [RETURNS MAP AND MRR VALUES] ######################
@@ -94,17 +99,17 @@ def map_mrr(pred_fname, th = 10):
     return map(dic,th), mrr(dic,th)
 
 def eval_metric(lrmodel, X_test_l, X_test_r, res_fname,pred_fname,use_softmax=True, feat_test=None):
-    
+
     if feat_test!=None:
         pred = lrmodel.predict([X_test_l, X_test_r, feat_test])[:,1]
     else:
         pred = lrmodel.predict([X_test_l, X_test_r])[:,1]
 
     ################### SAVING PREDICTIONS ###################
-    
+
     f1 = open(res_fname, 'r').readlines()
     f2 = open(pred_fname,'w')
-    
+
     for j,line in enumerate(f1):
         line = line.split('\t')
         #val = [line[0]+'\t',line[1]+'\t',line[2]+'\t',str(pred[j][0])+'\t',line[-1]]
@@ -113,13 +118,13 @@ def eval_metric(lrmodel, X_test_l, X_test_r, res_fname,pred_fname,use_softmax=Tr
         else:
             val = [line[0]+'\t',line[1]+'\t',line[2]+'\t',str(pred[j][0])+'\t',line[-1]]
         f2.writelines(val)
-    
+
     f2.close()
-    
+
     ################### PRINTING AND SAVING MAP-MRR VALUES ###################
-    
+
     map_val, mrr_val = map_mrr(pred_fname)
-    
+
     #print 'MAP:', map_val
     #print 'MRR:', mrr_val
     return map_val, mrr_val
@@ -133,5 +138,5 @@ def eval_sick(model,X_test_l,X_test_r,test_score):
     sp_coef = measures.spearmanr(pred,test_score)[0]
     per_coef = measures.pearsonr(pred,test_score)[0]
     mse_coef = np.mean(np.square(pred-test_score))
-    
+
     return sp_coef, per_coef, mse_coef

--- a/Attention_Based_CNN (ABCNN)/dl_text/model.py
+++ b/Attention_Based_CNN (ABCNN)/dl_text/model.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import print_function
 from keras.models import Model
 from keras.layers.core import Dense, Reshape, Permute
 from keras.layers import Input, merge, ZeroPadding2D,GlobalAveragePooling2D,GlobalMaxPooling1D,GlobalAveragePooling1D,ZeroPadding1D,AveragePooling1D, GlobalMaxPooling2D, Dropout, Merge, Conv1D, Lambda, Flatten,  Conv2D, MaxPooling2D, UpSampling2D, Convolution2D
@@ -11,7 +12,7 @@ from dl_text.dl import word2vec_embedding_layer
 def cnn(embedding_matrix, dimx=50, dimy=50, nb_filter = 120, 
         embedding_dim = 50,filter_length = (50,4), vocab_size = 8000, depth = 1):
 
-    print 'Model Uses Basic CNN......'
+    print('Model Uses Basic CNN......')
     
     inpx = Input(shape=(dimx,),dtype='int32',name='inpx')   
     inpy = Input(shape=(dimy,),dtype='int32',name='inpy')
@@ -73,7 +74,7 @@ def cnn(embedding_matrix, dimx=50, dimy=50, nb_filter = 120,
 def cnn_ft(embedding_matrix, dimx=50, dimy=50, dimft=44, nb_filter = 120, 
         embedding_dim = 50,filter_length = (50,4), vocab_size = 8000, depth = 1):
 
-    print 'Model Uses CNN with Features......'
+    print('Model Uses CNN with Features......')
     
     inpx = Input(shape=(dimx,),dtype='int32',name='inpx')   
     inpy = Input(shape=(dimy,),dtype='int32',name='inpy')

--- a/Attention_Based_CNN (ABCNN)/main.py
+++ b/Attention_Based_CNN (ABCNN)/main.py
@@ -3,6 +3,7 @@
 ** dl-lab **
 created by :: GauravBh1010tt
 """
+from __future__ import print_function
 
 import model_abcnn as model
 import wiki_utils as wk
@@ -14,7 +15,7 @@ glove_fname = 'D:/workspace/NLP/data/Glove/glove.6B.50d.txt'
 ################### DEFINING MODEL AND PREDICTION FILE ###################
 
 lrmodel = model.abcnn
-model_name = lrmodel.func_name
+model_name = lrmodel.__name__
 
 ################### DEFINING HYPERPARAMETERS ###################
 
@@ -46,7 +47,7 @@ if model_name == 'abcnn':
                       filter_length = filter_length, depth = depth, shared = shared,
                       opt_params = opt_params)
     
-    print '\n',model_name,'model built \n'
+    print('\n',model_name,'model built \n')
     lrmodel.fit([X_train_l, X_train_r],label_train,batch_size=batch_size,nb_epoch=nb_epoch,verbose=2)
     map_val, mrr_val = eval_metric(lrmodel, X_test_l, X_test_r, res_fname, pred_fname, feat_test=feat_test)
 
@@ -55,9 +56,9 @@ else:
                       filter_length = filter_length, depth = depth, shared = shared,
                       opt_params = opt_params)
     
-    print '\n', model_name,'model built \n'
+    print('\n', model_name,'model built \n')
     lrmodel.fit([X_train_l, X_train_r],label_train,batch_size=batch_size,nb_epoch=nb_epoch,verbose=2)
     map_val, mrr_val = eval_metric(lrmodel, X_test_l, X_test_r, res_fname, pred_fname)
 
 
-print 'MAP : ',map_val,' MRR : ',mrr_val
+print('MAP : ',map_val,' MRR : ',mrr_val)

--- a/Attention_Based_CNN (ABCNN)/model_abcnn.py
+++ b/Attention_Based_CNN (ABCNN)/model_abcnn.py
@@ -3,6 +3,7 @@
 ** dl-lab **
 created by :: GauravBh1010tt
 """
+from __future__ import print_function
 
 import keras
 from keras.models import Model
@@ -19,17 +20,17 @@ def abcnn(embedding_matrix, attention=1, dimx=50, dimy=50, nb_filter = 72,
           filter_widths = [4,3,2], opt_params = [0.0008,'adam']):
 
 #if True:
-    print '\n Model Uses ABCNN architecture ......'
-    print 'attention : ', attention
-    print 'nb_filters :', nb_filter
-    print 'filter_size :', filter_length
-    print 'opt params :',opt_params
+    print('\n Model Uses ABCNN architecture ......')
+    print('attention : ', attention)
+    print('nb_filters :', nb_filter)
+    print('filter_size :', filter_length)
+    print('opt params :',opt_params)
     #print 'dense layer :',dense_neuron,' ',reg1
     if dropout:
-        print 'using dropout'
+        print('using dropout')
     if shared:
-        print 'using shared params'
-    print '\n'
+        print('using shared params')
+    print('\n')
     
     inpx = Input(shape=(dimx,),dtype='int32',name='inpx')   
     inpy = Input(shape=(dimy,),dtype='int32',name='inpy')
@@ -146,7 +147,7 @@ def bcnn(embedding_matrix, dimx=50, dimy=50, nb_filter = 120, embedding_dim = 50
                       opt_params = [0.0008,'adam']):
 
 #if True:
-    print 'Model Uses BCNN......'
+    print('Model Uses BCNN......')
     
     inpx = Input(shape=(dimx,),dtype='int32',name='inpx')   
     inpy = Input(shape=(dimy,),dtype='int32',name='inpy')

--- a/Attention_recurrent_models/dl_text/dl.py
+++ b/Attention_recurrent_models/dl_text/dl.py
@@ -3,6 +3,7 @@
 ** dl-lab **
 created by :: GauravBh1010tt
 """
+from __future__ import print_function
 
 import re
 import numpy as np
@@ -65,7 +66,7 @@ def process_data(sent_l,sent_r=None,wordVec_model=None,dimx=100,dimy=100,vocab_s
     
     
     freq = FreqDist(chain(*tokenize_sent))
-    print 'found ',len(freq),' unique words'
+    print('found ',len(freq),' unique words')
     vocab = freq.most_common(vocab_size - 1)
     index_to_word = [x[0] for x in vocab]
     index_to_word.append(unk_token)
@@ -127,8 +128,8 @@ def process_data(sent_l,sent_r=None,wordVec_model=None,dimx=100,dimy=100,vocab_s
                 #print j
                 unk.append(j)
                 continue
-        print 'number of unkown words: ',len(unk)
-        print 'some unknown words ',unk[0:5]
+        print('number of unkown words: ',len(unk))
+        print('some unknown words ',unk[0:5])
     
     
     
@@ -158,7 +159,7 @@ def word2vec_embedding_layer(embedding_matrix,train=False):
     return layer
 
 def loadGloveModel(glovefile):
-    print 'Loading Glove File.....'
+    print('Loading Glove File.....')
     f = open(glovefile)
     model = {}
     for line in f:
@@ -166,8 +167,8 @@ def loadGloveModel(glovefile):
         word = splitline[0]
         embedding = np.array([float(val) for val in splitline[1:]])
         model[word] = embedding
-    print 'Loaded Word2Vec GloVe Model.....'
-    print len(model), ' words loaded.....'
+    print('Loaded Word2Vec GloVe Model.....')
+    print(len(model), ' words loaded.....')
     return model
 
 def encode_labels(labels, nclass=5):

--- a/Attention_recurrent_models/dl_text/lex_sem_ft.py
+++ b/Attention_recurrent_models/dl_text/lex_sem_ft.py
@@ -3,6 +3,7 @@
 ** dl-lab **
 created by :: GauravBh1010tt
 """
+from __future__ import print_function
 
 import pandas as pd
 import numpy as np

--- a/Attention_recurrent_models/dl_text/metrics.py
+++ b/Attention_recurrent_models/dl_text/metrics.py
@@ -11,6 +11,11 @@ from collections import defaultdict
 import scipy.stats as measures
 import numpy as np
 
+try:
+    xrange          # Python 2
+except NameError:
+    xrange = range  # Python 3
+
 ###################### CALCULATING MRR [RETURNS MRR VALUE] ######################
 
 def mrr(out, th = 10):
@@ -38,10 +43,10 @@ def map(out, th):
       if candidates[i] == "true":
         num_correct += 1
         precisions.append(num_correct/(i+1))
-    
+
     if precisions:
       avg_prec = sum(precisions)/len(precisions)
-    
+
     MAP += avg_prec
   return MAP / num_queries
 
@@ -53,7 +58,7 @@ def list2dict(lst):
 
     for i in range(len(lst)):
         interm[i+1] = lst[i]
-    
+
     for qid in interm:
         interm[qid] = sorted(interm[qid], key = itemgetter(0), reverse = True)
         val = [rel for score, rel in interm[qid]]
@@ -68,11 +73,11 @@ def list2dict(lst):
 def readfile(pred_fname):
     pred = open(pred_fname).readlines()
     pred = [line.split('\t') for line in pred]
-    
+
     ques = []
     ans = []
     i = 1
-    
+
     while i != len(pred):
         if pred[i][0] == pred[i-1][0]:
             ans.append([float(pred[i-1][-2]), pred[i-1][-1][0:-1]])
@@ -83,7 +88,7 @@ def readfile(pred_fname):
         i += 1
     ans.append([float(pred[i-1][-2]), pred[i-1][-1][0:-1]])
     ques.append(ans)
-    
+
     return ques
 
 ###################### MAP AND MRR FUNCTION [RETURNS MAP AND MRR VALUES] ######################
@@ -94,17 +99,17 @@ def map_mrr(pred_fname, th = 10):
     return map(dic,th), mrr(dic,th)
 
 def eval_metric(lrmodel, X_test_l, X_test_r, res_fname,pred_fname,use_softmax=True, feat_test=None):
-    
+
     if feat_test!=None:
         pred = lrmodel.predict([X_test_l, X_test_r, feat_test])[:,1]
     else:
         pred = lrmodel.predict([X_test_l, X_test_r])[:,1]
 
     ################### SAVING PREDICTIONS ###################
-    
+
     f1 = open(res_fname, 'r').readlines()
     f2 = open(pred_fname,'w')
-    
+
     for j,line in enumerate(f1):
         line = line.split('\t')
         #val = [line[0]+'\t',line[1]+'\t',line[2]+'\t',str(pred[j][0])+'\t',line[-1]]
@@ -113,13 +118,13 @@ def eval_metric(lrmodel, X_test_l, X_test_r, res_fname,pred_fname,use_softmax=Tr
         else:
             val = [line[0]+'\t',line[1]+'\t',line[2]+'\t',str(pred[j][0])+'\t',line[-1]]
         f2.writelines(val)
-    
+
     f2.close()
-    
+
     ################### PRINTING AND SAVING MAP-MRR VALUES ###################
-    
+
     map_val, mrr_val = map_mrr(pred_fname)
-    
+
     #print 'MAP:', map_val
     #print 'MRR:', mrr_val
     return map_val, mrr_val
@@ -133,5 +138,5 @@ def eval_sick(model,X_test_l,X_test_r,test_score):
     sp_coef = measures.spearmanr(pred,test_score)[0]
     per_coef = measures.pearsonr(pred,test_score)[0]
     mse_coef = np.mean(np.square(pred-test_score))
-    
+
     return sp_coef, per_coef, mse_coef

--- a/Attention_recurrent_models/dl_text/model.py
+++ b/Attention_recurrent_models/dl_text/model.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import print_function
 from keras.models import Model
 from keras.layers.core import Dense, Reshape, Permute
 from keras.layers import Input, merge, ZeroPadding2D,GlobalAveragePooling2D,GlobalMaxPooling1D,GlobalAveragePooling1D,ZeroPadding1D,AveragePooling1D, GlobalMaxPooling2D, Dropout, Merge, Conv1D, Lambda, Flatten,  Conv2D, MaxPooling2D, UpSampling2D, Convolution2D
@@ -11,7 +12,7 @@ from dl_text.dl import word2vec_embedding_layer
 def cnn(embedding_matrix, dimx=50, dimy=50, nb_filter = 120, 
         embedding_dim = 50,filter_length = (50,4), vocab_size = 8000, depth = 1):
 
-    print 'Model Uses Basic CNN......'
+    print('Model Uses Basic CNN......')
     
     inpx = Input(shape=(dimx,),dtype='int32',name='inpx')   
     inpy = Input(shape=(dimy,),dtype='int32',name='inpy')
@@ -73,7 +74,7 @@ def cnn(embedding_matrix, dimx=50, dimy=50, nb_filter = 120,
 def cnn_ft(embedding_matrix, dimx=50, dimy=50, dimft=44, nb_filter = 120, 
         embedding_dim = 50,filter_length = (50,4), vocab_size = 8000, depth = 1):
 
-    print 'Model Uses CNN with Features......'
+    print('Model Uses CNN with Features......')
     
     inpx = Input(shape=(dimx,),dtype='int32',name='inpx')   
     inpy = Input(shape=(dimy,),dtype='int32',name='inpy')

--- a/Attention_recurrent_models/main.py
+++ b/Attention_recurrent_models/main.py
@@ -3,6 +3,7 @@
 ** dl-lab **
 created by :: GauravBh1010tt
 """
+from __future__ import print_function
 
 import model_WALSTM as model
 import wiki_utils as wk
@@ -14,7 +15,7 @@ glove_fname = 'D:/workspace/NLP/data/Glove/glove.6B.50d.txt'
 ################### DEFINING MODEL AND PREDICTION FILE ###################
 
 lrmodel = model.WA_LSTM
-model_name = lrmodel.func_name
+model_name = lrmodel.__name__
 
 ################### DEFINING HYPERPARAMETERS ###################
 
@@ -43,9 +44,9 @@ X_train_l,X_test_l,X_dev_l,X_train_r,X_test_r,X_dev_r = wk.prepare_train_test(da
 lrmodel = lrmodel(embedding_matrix, dimx=dimx, dimy=dimy, LSTM_neurons = LSTM_neurons, embedding_dim = embedding_dim, 
                       depth = depth, shared = shared,opt_params = opt_params)
     
-print '\n', model_name,'model built \n'
+print('\n', model_name,'model built \n')
 lrmodel.fit([X_train_l, X_train_r],label_train,batch_size=batch_size,nb_epoch=nb_epoch,verbose=2)
 map_val, mrr_val = eval_metric(lrmodel, X_test_l, X_test_r, res_fname, pred_fname)
 
 
-print 'MAP : ',map_val,' MRR : ',mrr_val
+print('MAP : ',map_val,' MRR : ',mrr_val)

--- a/Attention_recurrent_models/model_WALSTM.py
+++ b/Attention_recurrent_models/model_WALSTM.py
@@ -3,6 +3,7 @@
 ** dl-lab **
 created by :: GauravBh1010tt
 """
+from __future__ import print_function
 
 import keras
 from keras.models import Model
@@ -17,7 +18,7 @@ def WA_LSTM(embedding_matrix, dimx=50, dimy=50, nb_filter = 120, embedding_dim =
                       filter_length = (50,4), depth = 1, shared = 0,LSTM_neurons=64,word_level=1,
                       opt_params = [0.0008,'adam']):
 
-    print 'Model Uses Attenion+LSTM......'
+    print('Model Uses Attenion+LSTM......')
     
     inpx = Input(shape=(dimx,),dtype='int32',name='inpx')   
     inpy = Input(shape=(dimy,),dtype='int32',name='inpy')

--- a/Attention_recurrent_models/model_abcnn.py
+++ b/Attention_recurrent_models/model_abcnn.py
@@ -3,6 +3,7 @@
 ** dl-lab **
 created by :: GauravBh1010tt
 """
+from __future__ import print_function
 
 import model_abcnn as model
 import wiki_utils as wk
@@ -14,7 +15,7 @@ glove_fname = 'D:/workspace/NLP/data/Glove/glove.6B.50d.txt'
 ################### DEFINING MODEL AND PREDICTION FILE ###################
 
 lrmodel = model.abcnn
-model_name = lrmodel.func_name
+model_name = lrmodel.__name__
 
 ################### DEFINING HYPERPARAMETERS ###################
 
@@ -46,7 +47,7 @@ if model_name == 'abcnn':
                       filter_length = filter_length, depth = depth, shared = shared,
                       opt_params = opt_params)
     
-    print '\n',model_name,'model built \n'
+    print('\n',model_name,'model built \n')
     lrmodel.fit([X_train_l, X_train_r],label_train,batch_size=batch_size,nb_epoch=nb_epoch,verbose=2)
     map_val, mrr_val = eval_metric(lrmodel, X_test_l, X_test_r, res_fname, pred_fname)
 
@@ -55,9 +56,9 @@ else:
                       filter_length = filter_length, depth = depth, shared = shared,
                       opt_params = opt_params)
     
-    print '\n', model_name,'model built \n'
+    print('\n', model_name,'model built \n')
     lrmodel.fit([X_train_l, X_train_r],label_train,batch_size=batch_size,nb_epoch=nb_epoch,verbose=2)
     map_val, mrr_val = eval_metric(lrmodel, X_test_l, X_test_r, res_fname, pred_fname)
 
 
-print 'MAP : ',map_val,' MRR : ',mrr_val
+print('MAP : ',map_val,' MRR : ',mrr_val)

--- a/CorrNet/DeepLearn_cornet.py
+++ b/CorrNet/DeepLearn_cornet.py
@@ -6,6 +6,7 @@ Created on Tue Mar 07 11:48:18 2017
 @author: Gaurav Bhatt
 Email - gauravbhatt.cs.iitr@gmail.com
 """
+from __future__ import print_function
 
 import sys
 import math
@@ -36,7 +37,7 @@ lamda = 0.02
 loss_type = 2 # 1 - l1+l2+l3-L4; 2 - l2+l3-L4; 3 - l1+l2+l3 , 4 - l2+l3
 
 def svm_classifier(train_x, train_y, valid_x, valid_y, test_x, test_y):
-    
+
     clf = svm.LinearSVC()
     #print train_x.shape,train_y.shape
     clf.fit(train_x,train_y)
@@ -47,7 +48,7 @@ def svm_classifier(train_x, train_y, valid_x, valid_y, test_x, test_y):
     return va, ta
 
 def split(train_l,train_r,label,ratio):
-    
+
     total = train_l.shape[0]
     train_samples = int(total*(1-ratio))
     test_samples = total-train_samples
@@ -57,23 +58,23 @@ def split(train_l,train_r,label,ratio):
         tr_l.append(train_l[a,:])
         tr_r.append(train_r[a,:])
         l_tr.append(label[a])
-        
+
     for i in range(test_samples):
         if i not in dat:
             tst_l.append(train_l[i,:])
             tst_r.append(train_r[i,:])
             l_tst.append(label[i])
-            
+
     tr_l = np.array(tr_l)
     tr_r = np.array(tr_r)
     tst_l = np.array(tst_l)
     tst_r = np.array(tst_r)
     l_tr = np.array(l_tr)
     l_tst = np.array(l_tst)
-    
+
     return tr_l,tst_l,tr_r,tst_r,l_tr,l_tst
-    
-    
+
+
 class ZeroPadding(Layer):
     def __init__(self, **kwargs):
         super(ZeroPadding, self).__init__(**kwargs)
@@ -150,30 +151,30 @@ def reconstruct_from_right(model,inp):
     img = pred[1].reshape((28,14))
     axarr[1].imshow(img_inp)
     axarr[0].imshow(img)
-    
+
 def sum_corr(model):
     view1 = np.load("test_v1.npy")
     view2 = np.load("test_v2.npy")
     x = project(model,[view1,np.zeros_like(view1)])
     y = project(model,[np.zeros_like(view2),view2])
-    print "test correlation"
+    print("test correlation")
     corr = 0
     for i in range(0,len(x[0])):
 		x1 = x[:,i] - (np.ones(len(x))*(sum(x[:,i])/len(x)))
 		x2 = y[:,i] - (np.ones(len(y))*(sum(y[:,i])/len(y)))
 		nr = sum(x1 * x2)/(math.sqrt(sum(x1*x1))*math.sqrt(sum(x2*x2)))
 		corr+=nr
-    print corr
- 
+    print(corr)
+
 def transfer(model):
     view1 = np.load("test_v1.npy")
     view2 = np.load("test_v2.npy")
     labels = np.load("test_l.npy")
     view1 = project(model,[view1,np.zeros_like(view1)])
     view2 = project(model,[np.zeros_like(view2),view2])
-    
+
     perp = len(view1)/5
-    print "view1 to view2"
+    print("view1 to view2")
     acc = 0
     for i in range(0,5):
 		test_x = view2[i*perp:(i+1)*perp]
@@ -191,11 +192,11 @@ def transfer(model):
 			train_y2 = labels[(i+1)*perp:len(view1)]
 			train_x = np.concatenate((train_x1,train_x2))
 			train_y = np.concatenate((train_y1,train_y2))
-       
+
 		va, ta = svm_classifier(train_x, train_y, test_x, test_y, test_x, test_y)
 		acc += ta
-    print acc/5
-    print "view2 to view1"
+    print(acc/5)
+    print("view2 to view1")
 
     acc = 0
     for i in range(0,5):
@@ -216,7 +217,7 @@ def transfer(model):
 			train_y = np.concatenate((train_y1,train_y2))
 		va, ta = svm_classifier(train_x, train_y, test_x, test_y, test_x, test_y)
 		acc += ta
-    print acc/5
+    print(acc/5)
 
 def prepare_data():
     data_l = np.load('data_l.npy')
@@ -233,19 +234,19 @@ def buildModel(loss_type,lamda):
     hx = Dense(hdim_deep,activation='sigmoid')(inpx)
     hx = Dense(hdim_deep2, activation='sigmoid',name='hid_l1')(hx)
     hx = Dense(hdim, activation='sigmoid',name='hid_l')(hx)
-    
+
     hy = Dense(hdim_deep,activation='sigmoid')(inpy)
     hy = Dense(hdim_deep2, activation='sigmoid',name='hid_r1')(hy)
     hy = Dense(hdim, activation='sigmoid',name='hid_r')(hy)
 
     #h = Activation("sigmoid")( Merge(mode="sum")([hx,hy]) )
-    h =  Merge(mode="sum")([hx,hy]) 
-    
+    h =  Merge(mode="sum")([hx,hy])
+
     #recx = Dense(hdim_deep,activation='sigmoid')(h)
     recx = Dense(dimx)(h)
     #recy = Dense(hdim_deep,activation='sigmoid')(h)
     recy = Dense(dimy)(h)
-    
+
     branchModel = Model( [inpx,inpy],[recx,recy,h])
 
     #inpx = Input(shape=(dimx,))
@@ -258,7 +259,7 @@ def buildModel(loss_type,lamda):
     [recx3,recy3,h] = branchModel([inpx, inpy])
 
     corr=CorrnetCost(-lamda)([h1,h2])
-    
+
     if loss_type == 1:
         model = Model( [inpx,inpy],[recy1,recx2,recx3,recx1,recy2,recy3,corr])
         model.compile( loss=["mse","mse","mse","mse","mse","mse",corr_loss],optimizer="rmsprop")
@@ -280,30 +281,30 @@ def trainModel(model,data_left,data_right,loss_type,nb_epoch,batch_size):
     X_train_r = data_right
     #y_train = np_utils.to_categorical(y_train, nb_classes)
     #y_test = np_utils.to_categorical(y_test, nb_classes)
-    
+
     data_l = np.load('data_l.npy')
     data_r = np.load('data_r.npy')
     label = np.load('data_label.npy')
     X_train_l, X_test_l, X_train_r, X_test_r,y_train,y_test = split(data_l,data_r,label,ratio=0.01)
-    
-    print 'data split'
+
+    print('data split')
     if loss_type == 1:
-        print 'L_Type: l1+l2+l3-L4   h_dim:',hdim,'  lamda:',lamda
+        print('L_Type: l1+l2+l3-L4   h_dim:',hdim,'  lamda:',lamda)
         model.fit([X_train_l,X_train_r], [X_train_r,X_train_l,X_train_l,X_train_l,X_train_r,X_train_r,np.zeros((X_train_l.shape[0],h_loss))],
                   nb_epoch=nb_epoch,
                   batch_size=batch_size,verbose=0)
     elif loss_type == 2:
-        print 'L_Type: l2+l3-L4   h_dim:',hdim,'   hdim_deep',hdim_deep,'  lamda:',lamda
+        print('L_Type: l2+l3-L4   h_dim:',hdim,'   hdim_deep',hdim_deep,'  lamda:',lamda)
         model.fit([X_train_l,X_train_r], [X_train_r,X_train_l,X_train_l,X_train_r,np.zeros((X_train_l.shape[0],h_loss))],
               nb_epoch=nb_epoch,
               batch_size=batch_size,verbose=0)
     elif loss_type == 3:
-        print 'L_Type: l1+l2+l3   h_dim:',hdim,'  lamda:',lamda
+        print('L_Type: l1+l2+l3   h_dim:',hdim,'  lamda:',lamda)
         model.fit([X_train_l,X_train_r], [X_train_r,X_train_l,X_train_l,X_train_l,X_train_r,X_train_r],
               nb_epoch=nb_epoch,
               batch_size=batch_size,verbose=0)
     elif loss_type == 4:
-        print 'L_Type: l2+l3   h_dim:',hdim,'  lamda:',lamda
+        print('L_Type: l2+l3   h_dim:',hdim,'  lamda:',lamda)
         model.fit([X_train_l,X_train_r], [X_train_r,X_train_l,X_train_l,X_train_r],
               nb_epoch=nb_epoch,
               batch_size=batch_size,verbose=0)
@@ -317,6 +318,6 @@ def testModel(b_model):
 
 left_view, right_view = prepare_data()
 model,branchModel = buildModel(loss_type=loss_type,lamda=lamda)
-trainModel(model=model, data_left=left_view, data_right = right_view, 
+trainModel(model=model, data_left=left_view, data_right = right_view,
            loss_type=loss_type,nb_epoch=nb_epoch,batch_size=batch_size)
 testModel(branchModel)

--- a/MaLSTM (Siamese)/dl_text/dl.py
+++ b/MaLSTM (Siamese)/dl_text/dl.py
@@ -3,6 +3,7 @@
 ** dl-lab **
 created by :: GauravBh1010tt
 """
+from __future__ import print_function
 
 import re
 import numpy as np
@@ -65,7 +66,7 @@ def process_data(sent_l,sent_r=None,wordVec_model=None,dimx=100,dimy=100,vocab_s
     
     
     freq = FreqDist(chain(*tokenize_sent))
-    print 'found ',len(freq),' unique words'
+    print('found ',len(freq),' unique words')
     vocab = freq.most_common(vocab_size - 1)
     index_to_word = [x[0] for x in vocab]
     index_to_word.append(unk_token)
@@ -127,8 +128,8 @@ def process_data(sent_l,sent_r=None,wordVec_model=None,dimx=100,dimy=100,vocab_s
                 #print j
                 unk.append(j)
                 continue
-        print 'number of unkown words: ',len(unk)
-        print 'some unknown words ',unk[0:5]
+        print('number of unkown words: ',len(unk))
+        print('some unknown words ',unk[0:5])
     
     
     
@@ -158,7 +159,7 @@ def word2vec_embedding_layer(embedding_matrix,train=False):
     return layer
 
 def loadGloveModel(glovefile):
-    print 'Loading Glove File.....'
+    print('Loading Glove File.....')
     f = open(glovefile)
     model = {}
     for line in f:
@@ -166,8 +167,8 @@ def loadGloveModel(glovefile):
         word = splitline[0]
         embedding = np.array([float(val) for val in splitline[1:]])
         model[word] = embedding
-    print 'Loaded Word2Vec GloVe Model.....'
-    print len(model), ' words loaded.....'
+    print('Loaded Word2Vec GloVe Model.....')
+    print(len(model), ' words loaded.....')
     return model
 
 def encode_labels(labels, nclass=5):

--- a/MaLSTM (Siamese)/dl_text/lex_sem_ft.py
+++ b/MaLSTM (Siamese)/dl_text/lex_sem_ft.py
@@ -3,6 +3,7 @@
 ** dl-lab **
 created by :: GauravBh1010tt
 """
+from __future__ import print_function
 
 import pandas as pd
 import numpy as np

--- a/MaLSTM (Siamese)/dl_text/metrics.py
+++ b/MaLSTM (Siamese)/dl_text/metrics.py
@@ -11,6 +11,11 @@ from collections import defaultdict
 import scipy.stats as measures
 import numpy as np
 
+try:
+    xrange          # Python 2
+except NameError:
+    xrange = range  # Python 3
+
 ###################### CALCULATING MRR [RETURNS MRR VALUE] ######################
 
 def mrr(out, th = 10):
@@ -38,10 +43,10 @@ def map(out, th):
       if candidates[i] == "true":
         num_correct += 1
         precisions.append(num_correct/(i+1))
-    
+
     if precisions:
       avg_prec = sum(precisions)/len(precisions)
-    
+
     MAP += avg_prec
   return MAP / num_queries
 
@@ -53,7 +58,7 @@ def list2dict(lst):
 
     for i in range(len(lst)):
         interm[i+1] = lst[i]
-    
+
     for qid in interm:
         interm[qid] = sorted(interm[qid], key = itemgetter(0), reverse = True)
         val = [rel for score, rel in interm[qid]]
@@ -68,11 +73,11 @@ def list2dict(lst):
 def readfile(pred_fname):
     pred = open(pred_fname).readlines()
     pred = [line.split('\t') for line in pred]
-    
+
     ques = []
     ans = []
     i = 1
-    
+
     while i != len(pred):
         if pred[i][0] == pred[i-1][0]:
             ans.append([float(pred[i-1][-2]), pred[i-1][-1][0:-1]])
@@ -83,7 +88,7 @@ def readfile(pred_fname):
         i += 1
     ans.append([float(pred[i-1][-2]), pred[i-1][-1][0:-1]])
     ques.append(ans)
-    
+
     return ques
 
 ###################### MAP AND MRR FUNCTION [RETURNS MAP AND MRR VALUES] ######################
@@ -94,17 +99,17 @@ def map_mrr(pred_fname, th = 10):
     return map(dic,th), mrr(dic,th)
 
 def eval_metric(lrmodel, X_test_l, X_test_r, res_fname,pred_fname,use_softmax=True, feat_test=None):
-    
+
     if feat_test!=None:
         pred = lrmodel.predict([X_test_l, X_test_r, feat_test])[:,1]
     else:
         pred = lrmodel.predict([X_test_l, X_test_r])[:,1]
 
     ################### SAVING PREDICTIONS ###################
-    
+
     f1 = open(res_fname, 'r').readlines()
     f2 = open(pred_fname,'w')
-    
+
     for j,line in enumerate(f1):
         line = line.split('\t')
         #val = [line[0]+'\t',line[1]+'\t',line[2]+'\t',str(pred[j][0])+'\t',line[-1]]
@@ -113,13 +118,13 @@ def eval_metric(lrmodel, X_test_l, X_test_r, res_fname,pred_fname,use_softmax=Tr
         else:
             val = [line[0]+'\t',line[1]+'\t',line[2]+'\t',str(pred[j][0])+'\t',line[-1]]
         f2.writelines(val)
-    
+
     f2.close()
-    
+
     ################### PRINTING AND SAVING MAP-MRR VALUES ###################
-    
+
     map_val, mrr_val = map_mrr(pred_fname)
-    
+
     #print 'MAP:', map_val
     #print 'MRR:', mrr_val
     return map_val, mrr_val
@@ -133,5 +138,5 @@ def eval_sick(model,X_test_l,X_test_r,test_score):
     sp_coef = measures.spearmanr(pred,test_score)[0]
     per_coef = measures.pearsonr(pred,test_score)[0]
     mse_coef = np.mean(np.square(pred-test_score))
-    
+
     return sp_coef, per_coef, mse_coef

--- a/MaLSTM (Siamese)/main.py
+++ b/MaLSTM (Siamese)/main.py
@@ -3,6 +3,7 @@
 ** dl-lab **
 created by :: GauravBh1010tt
 """
+from __future__ import print_function
 
 import model_Siam_LSTM as model
 from dl_text.metrics import eval_sick
@@ -11,7 +12,7 @@ import sick_utils as sick
 import numpy as np
 
 lrmodel = model.S_LSTM
-model_name = lrmodel.func_name
+model_name = lrmodel.__name__
 
 embedding_dim = 300
 LSTM_neurons = 50
@@ -32,7 +33,7 @@ data_l, data_r, embedding_matrix = dl.process_data(sent1, sent2,
 X_train_l,X_test_l,X_dev_l,X_train_r,X_test_r,X_dev_r = dl.prepare_train_test(data_l,data_r,
                                                                               train_len,test_len)        
    
-print '\n', model_name,'model built \n'
+print('\n', model_name,'model built \n')
     
 lrmodel = lrmodel(dimx = dimx, dimy = dimy, embedding_matrix=embedding_matrix, 
                    LSTM_neurons = LSTM_neurons)
@@ -41,9 +42,9 @@ lrmodel.fit([X_train_l,X_train_r],
                  nb_epoch=epochs,
                  batch_size=batch_size,verbose=1)
 
-print '\n evaluating performance \n'
+print('\n evaluating performance \n')
 
 sp_coef, per_coef, mse = eval_sick(lrmodel, X_test_l, X_test_r, test_score)
-print 'spearman coef :',sp_coef
-print 'pearson coef :',per_coef
-print 'mse :',mse
+print('spearman coef :',sp_coef)
+print('pearson coef :',per_coef)
+print('mse :',mse)

--- a/TrecQA_CNN+Sim/dl_text/dl.py
+++ b/TrecQA_CNN+Sim/dl_text/dl.py
@@ -3,6 +3,7 @@
 ** dl-lab **
 created by :: GauravBh1010tt
 """
+from __future__ import print_function
 
 import re
 import numpy as np
@@ -65,7 +66,7 @@ def process_data(sent_l,sent_r=None,wordVec_model=None,dimx=100,dimy=100,vocab_s
     
     
     freq = FreqDist(chain(*tokenize_sent))
-    print 'found ',len(freq),' unique words'
+    print('found ',len(freq),' unique words')
     vocab = freq.most_common(vocab_size - 1)
     index_to_word = [x[0] for x in vocab]
     index_to_word.append(unk_token)
@@ -127,8 +128,8 @@ def process_data(sent_l,sent_r=None,wordVec_model=None,dimx=100,dimy=100,vocab_s
                 #print j
                 unk.append(j)
                 continue
-        print 'number of unkown words: ',len(unk)
-        print 'some unknown words ',unk[0:5]
+        print('number of unkown words: ',len(unk))
+        print('some unknown words ',unk[0:5])
     
     
     
@@ -158,7 +159,7 @@ def word2vec_embedding_layer(embedding_matrix,train=False):
     return layer
 
 def loadGloveModel(glovefile):
-    print 'Loading Glove File.....'
+    print('Loading Glove File.....')
     f = open(glovefile)
     model = {}
     for line in f:
@@ -166,8 +167,8 @@ def loadGloveModel(glovefile):
         word = splitline[0]
         embedding = np.array([float(val) for val in splitline[1:]])
         model[word] = embedding
-    print 'Loaded Word2Vec GloVe Model.....'
-    print len(model), ' words loaded.....'
+    print('Loaded Word2Vec GloVe Model.....')
+    print(len(model), ' words loaded.....')
     return model
 
 def encode_labels(labels, nclass=5):

--- a/TrecQA_CNN+Sim/dl_text/lex_sem_ft.py
+++ b/TrecQA_CNN+Sim/dl_text/lex_sem_ft.py
@@ -3,6 +3,7 @@
 ** dl-lab **
 created by :: GauravBh1010tt
 """
+from __future__ import print_function
 
 import pandas as pd
 import numpy as np

--- a/TrecQA_CNN+Sim/dl_text/metrics.py
+++ b/TrecQA_CNN+Sim/dl_text/metrics.py
@@ -11,6 +11,11 @@ from collections import defaultdict
 import scipy.stats as measures
 import numpy as np
 
+try:
+    xrange          # Python 2
+except NameError:
+    xrange = range  # Python 3
+
 ###################### CALCULATING MRR [RETURNS MRR VALUE] ######################
 
 def mrr(out, th = 10):
@@ -38,10 +43,10 @@ def map(out, th):
       if candidates[i] == "true":
         num_correct += 1
         precisions.append(num_correct/(i+1))
-    
+
     if precisions:
       avg_prec = sum(precisions)/len(precisions)
-    
+
     MAP += avg_prec
   return MAP / num_queries
 
@@ -53,7 +58,7 @@ def list2dict(lst):
 
     for i in range(len(lst)):
         interm[i+1] = lst[i]
-    
+
     for qid in interm:
         interm[qid] = sorted(interm[qid], key = itemgetter(0), reverse = True)
         val = [rel for score, rel in interm[qid]]
@@ -68,11 +73,11 @@ def list2dict(lst):
 def readfile(pred_fname):
     pred = open(pred_fname).readlines()
     pred = [line.split('\t') for line in pred]
-    
+
     ques = []
     ans = []
     i = 1
-    
+
     while i != len(pred):
         if pred[i][0] == pred[i-1][0]:
             ans.append([float(pred[i-1][-2]), pred[i-1][-1][0:-1]])
@@ -83,7 +88,7 @@ def readfile(pred_fname):
         i += 1
     ans.append([float(pred[i-1][-2]), pred[i-1][-1][0:-1]])
     ques.append(ans)
-    
+
     return ques
 
 ###################### MAP AND MRR FUNCTION [RETURNS MAP AND MRR VALUES] ######################
@@ -94,17 +99,17 @@ def map_mrr(pred_fname, th = 10):
     return map(dic,th), mrr(dic,th)
 
 def eval_metric(lrmodel, X_test_l, X_test_r, res_fname,pred_fname,use_softmax=True, feat_test=None):
-    
+
     if feat_test!=None:
         pred = lrmodel.predict([X_test_l, X_test_r, feat_test])[:,1]
     else:
         pred = lrmodel.predict([X_test_l, X_test_r])[:,1]
 
     ################### SAVING PREDICTIONS ###################
-    
+
     f1 = open(res_fname, 'r').readlines()
     f2 = open(pred_fname,'w')
-    
+
     for j,line in enumerate(f1):
         line = line.split('\t')
         #val = [line[0]+'\t',line[1]+'\t',line[2]+'\t',str(pred[j][0])+'\t',line[-1]]
@@ -113,13 +118,13 @@ def eval_metric(lrmodel, X_test_l, X_test_r, res_fname,pred_fname,use_softmax=Tr
         else:
             val = [line[0]+'\t',line[1]+'\t',line[2]+'\t',str(pred[j][0])+'\t',line[-1]]
         f2.writelines(val)
-    
+
     f2.close()
-    
+
     ################### PRINTING AND SAVING MAP-MRR VALUES ###################
-    
+
     map_val, mrr_val = map_mrr(pred_fname)
-    
+
     #print 'MAP:', map_val
     #print 'MRR:', mrr_val
     return map_val, mrr_val
@@ -133,5 +138,5 @@ def eval_sick(model,X_test_l,X_test_r,test_score):
     sp_coef = measures.spearmanr(pred,test_score)[0]
     per_coef = measures.pearsonr(pred,test_score)[0]
     mse_coef = np.mean(np.square(pred-test_score))
-    
+
     return sp_coef, per_coef, mse_coef

--- a/TrecQA_CNN+Sim/main.py
+++ b/TrecQA_CNN+Sim/main.py
@@ -3,6 +3,7 @@
 ** dl-lab **
 created by :: GauravBh1010tt
 """
+from __future__ import print_function
 
 #import numpy as np
 
@@ -16,7 +17,7 @@ glove_fname = 'D:/workspace/Trec_QA-master/data/Glove/glove.6B.50d.txt'
 ################### DEFINING MODEL AND PREDICTION FILE ###################
 
 lrmodel = model.cnn_sim_ft
-model_name = lrmodel.func_name
+model_name = lrmodel.__name__
 
 ################### DEFINING HYPERPARAMETERS ###################
 
@@ -46,7 +47,7 @@ if model_name == 'cnn_sim_ft':
                       embedding_dim = embedding_dim,filter_length = filter_length, vocab_size = vocab_size,
                       depth = depth)
     
-    print '\n',model_name,'model built \n'
+    print('\n',model_name,'model built \n')
     lrmodel.fit([X_train_l, X_train_r,feat_train],label_train,batch_size=batch_size,nb_epoch=nb_epoch,verbose=2)
     map_val, mrr_val = eval_metric(lrmodel, X_test_l, X_test_r, res_fname, pred_fname, feat_test=feat_test)
 
@@ -54,9 +55,9 @@ else:
     lrmodel = lrmodel(embedding_matrix, dimx=dimx, dimy=dimy, nb_filter = nb_filter, embedding_dim = embedding_dim,
                       filter_length = filter_length, vocab_size = vocab_size, depth = depth)
     
-    print '\n', model_name,'model built \n'
+    print('\n', model_name,'model built \n')
     lrmodel.fit([X_train_l, X_train_r],label_train,batch_size=batch_size,nb_epoch=nb_epoch,verbose=2)
     map_val, mrr_val = eval_metric(lrmodel, X_test_l, X_test_r, res_fname, pred_fname)
 
     
-print 'MAP : ',map_val,' MRR : ',mrr_val
+print('MAP : ',map_val,' MRR : ',mrr_val)

--- a/TrecQA_CNN+Sim/model_sim.py
+++ b/TrecQA_CNN+Sim/model_sim.py
@@ -3,6 +3,7 @@
 ** dl-lab **
 created by :: GauravBh1010tt
 """
+from __future__ import print_function
 
 from keras import backend as K
 from keras.models import Model
@@ -17,7 +18,7 @@ from dl_layers.layers import Similarity
 def cnn_sim(embedding_matrix, dimx=50, dimy=50, nb_filter = 120, 
         embedding_dim = 50,filter_length = (50,4), vocab_size = 8000, depth = 1):
 
-    print 'Model Uses CNN with Sim......'
+    print('Model Uses CNN with Sim......')
     
     inpx = Input(shape=(dimx,),dtype='int32',name='inpx')   
     inpy = Input(shape=(dimy,),dtype='int32',name='inpy')
@@ -83,7 +84,7 @@ def cnn_sim(embedding_matrix, dimx=50, dimy=50, nb_filter = 120,
 def cnn_sim_ft(embedding_matrix, dimx=50, dimy=50, dimft=44, nb_filter = 120, 
         embedding_dim = 50,filter_length = (50,4), vocab_size = 8000, depth = 1):
 
-    print 'Model Uses CNN with Sim and Features......'
+    print('Model Uses CNN with Sim and Features......')
     
     inpx = Input(shape=(dimx,),dtype='int32',name='inpx')   
     inpy = Input(shape=(dimy,),dtype='int32',name='inpy')

--- a/WikiQA_CNN+Feat/dl_text/dl.py
+++ b/WikiQA_CNN+Feat/dl_text/dl.py
@@ -3,6 +3,7 @@
 ** dl-lab **
 created by :: GauravBh1010tt
 """
+from __future__ import print_function
 
 import re
 import numpy as np
@@ -65,7 +66,7 @@ def process_data(sent_l,sent_r=None,wordVec_model=None,dimx=100,dimy=100,vocab_s
     
     
     freq = FreqDist(chain(*tokenize_sent))
-    print 'found ',len(freq),' unique words'
+    print('found ',len(freq),' unique words')
     vocab = freq.most_common(vocab_size - 1)
     index_to_word = [x[0] for x in vocab]
     index_to_word.append(unk_token)
@@ -127,8 +128,8 @@ def process_data(sent_l,sent_r=None,wordVec_model=None,dimx=100,dimy=100,vocab_s
                 #print j
                 unk.append(j)
                 continue
-        print 'number of unkown words: ',len(unk)
-        print 'some unknown words ',unk[0:5]
+        print('number of unkown words: ',len(unk))
+        print('some unknown words ',unk[0:5])
     
     
     
@@ -158,7 +159,7 @@ def word2vec_embedding_layer(embedding_matrix,train=False):
     return layer
 
 def loadGloveModel(glovefile):
-    print 'Loading Glove File.....'
+    print('Loading Glove File.....')
     f = open(glovefile)
     model = {}
     for line in f:
@@ -166,8 +167,8 @@ def loadGloveModel(glovefile):
         word = splitline[0]
         embedding = np.array([float(val) for val in splitline[1:]])
         model[word] = embedding
-    print 'Loaded Word2Vec GloVe Model.....'
-    print len(model), ' words loaded.....'
+    print('Loaded Word2Vec GloVe Model.....')
+    print(len(model), ' words loaded.....')
     return model
 
 def encode_labels(labels, nclass=5):

--- a/WikiQA_CNN+Feat/dl_text/lex_sem_ft.py
+++ b/WikiQA_CNN+Feat/dl_text/lex_sem_ft.py
@@ -3,6 +3,7 @@
 ** dl-lab **
 created by :: GauravBh1010tt
 """
+from __future__ import print_function
 
 import pandas as pd
 import numpy as np

--- a/WikiQA_CNN+Feat/dl_text/metrics.py
+++ b/WikiQA_CNN+Feat/dl_text/metrics.py
@@ -11,6 +11,11 @@ from collections import defaultdict
 import scipy.stats as measures
 import numpy as np
 
+try:
+    xrange          # Python 2
+except NameError:
+    xrange = range  # Python 3
+
 ###################### CALCULATING MRR [RETURNS MRR VALUE] ######################
 
 def mrr(out, th = 10):
@@ -38,10 +43,10 @@ def map(out, th):
       if candidates[i] == "true":
         num_correct += 1
         precisions.append(num_correct/(i+1))
-    
+
     if precisions:
       avg_prec = sum(precisions)/len(precisions)
-    
+
     MAP += avg_prec
   return MAP / num_queries
 
@@ -53,7 +58,7 @@ def list2dict(lst):
 
     for i in range(len(lst)):
         interm[i+1] = lst[i]
-    
+
     for qid in interm:
         interm[qid] = sorted(interm[qid], key = itemgetter(0), reverse = True)
         val = [rel for score, rel in interm[qid]]
@@ -68,11 +73,11 @@ def list2dict(lst):
 def readfile(pred_fname):
     pred = open(pred_fname).readlines()
     pred = [line.split('\t') for line in pred]
-    
+
     ques = []
     ans = []
     i = 1
-    
+
     while i != len(pred):
         if pred[i][0] == pred[i-1][0]:
             ans.append([float(pred[i-1][-2]), pred[i-1][-1][0:-1]])
@@ -83,7 +88,7 @@ def readfile(pred_fname):
         i += 1
     ans.append([float(pred[i-1][-2]), pred[i-1][-1][0:-1]])
     ques.append(ans)
-    
+
     return ques
 
 ###################### MAP AND MRR FUNCTION [RETURNS MAP AND MRR VALUES] ######################
@@ -94,17 +99,17 @@ def map_mrr(pred_fname, th = 10):
     return map(dic,th), mrr(dic,th)
 
 def eval_metric(lrmodel, X_test_l, X_test_r, res_fname,pred_fname,use_softmax=True, feat_test=None):
-    
+
     if feat_test!=None:
         pred = lrmodel.predict([X_test_l, X_test_r, feat_test])[:,1]
     else:
         pred = lrmodel.predict([X_test_l, X_test_r])[:,1]
 
     ################### SAVING PREDICTIONS ###################
-    
+
     f1 = open(res_fname, 'r').readlines()
     f2 = open(pred_fname,'w')
-    
+
     for j,line in enumerate(f1):
         line = line.split('\t')
         #val = [line[0]+'\t',line[1]+'\t',line[2]+'\t',str(pred[j][0])+'\t',line[-1]]
@@ -113,13 +118,13 @@ def eval_metric(lrmodel, X_test_l, X_test_r, res_fname,pred_fname,use_softmax=Tr
         else:
             val = [line[0]+'\t',line[1]+'\t',line[2]+'\t',str(pred[j][0])+'\t',line[-1]]
         f2.writelines(val)
-    
+
     f2.close()
-    
+
     ################### PRINTING AND SAVING MAP-MRR VALUES ###################
-    
+
     map_val, mrr_val = map_mrr(pred_fname)
-    
+
     #print 'MAP:', map_val
     #print 'MRR:', mrr_val
     return map_val, mrr_val
@@ -133,5 +138,5 @@ def eval_sick(model,X_test_l,X_test_r,test_score):
     sp_coef = measures.spearmanr(pred,test_score)[0]
     per_coef = measures.pearsonr(pred,test_score)[0]
     mse_coef = np.mean(np.square(pred-test_score))
-    
+
     return sp_coef, per_coef, mse_coef

--- a/WikiQA_CNN+Feat/main.py
+++ b/WikiQA_CNN+Feat/main.py
@@ -3,6 +3,7 @@
 ** dl-lab **
 created by :: GauravBh1010tt
 """
+from __future__ import print_function
 
 import numpy as np
 
@@ -16,7 +17,7 @@ glove_fname = 'D:/workspace/Trec_QA-master/data/Glove/glove.6B.50d.txt'
 ################### DEFINING MODEL ###################
 
 lrmodel = model.cnn
-model_name = lrmodel.func_name
+model_name = lrmodel.__name__
 
 ################### DEFINING HYPERPARAMETERS ###################
 
@@ -44,7 +45,7 @@ if model_name == 'cnn_ft':
     lrmodel = lrmodel(embedding_matrix, dimx=dimx, dimy=dimy, dimft=dimft, nb_filter = 120, 
                       embedding_dim = 50, filter_length = (50,4), vocab_size = 8000, depth = 1)
     
-    print '\n',model_name,'model built \n'
+    print('\n',model_name,'model built \n')
     lrmodel.fit([X_train_l, X_train_r,feat_train],label_train,batch_size=batch_size,nb_epoch=nb_epoch,verbose=2)
     map_val, mrr_val = eval_metric(lrmodel, X_test_l, X_test_r, res_fname, pred_fname, feat_test=feat_test)
 
@@ -52,9 +53,9 @@ else:
     lrmodel = lrmodel(embedding_matrix, dimx=dimx, dimy=dimy, nb_filter = 120, 
                       embedding_dim = 50, filter_length = (50,4), vocab_size = 8000, depth = 1)
     
-    print '\n', model_name,'model built \n'
+    print('\n', model_name,'model built \n')
     lrmodel.fit([X_train_l, X_train_r],label_train,batch_size=batch_size,nb_epoch=nb_epoch,verbose=2)
     map_val, mrr_val = eval_metric(lrmodel, X_test_l, X_test_r, res_fname, pred_fname)
 
     
-print 'MAP : ',map_val,' MRR : ',mrr_val
+print('MAP : ',map_val,' MRR : ',mrr_val)

--- a/WikiQA_CNN+Feat/model.py
+++ b/WikiQA_CNN+Feat/model.py
@@ -3,6 +3,7 @@
 ** dl-lab **
 created by :: GauravBh1010tt
 """
+from __future__ import print_function
 
 from keras.models import Model
 from keras.layers.core import Dense, Reshape, Permute
@@ -15,7 +16,7 @@ from dl import word2vec_embedding_layer
 def cnn(embedding_matrix, dimx=50, dimy=50, nb_filter = 120, 
         embedding_dim = 50,filter_length = (50,4), vocab_size = 8000, depth = 1):
 
-    print 'Model Uses Basic CNN......'
+    print('Model Uses Basic CNN......')
     
     inpx = Input(shape=(dimx,),dtype='int32',name='inpx')   
     inpy = Input(shape=(dimy,),dtype='int32',name='inpy')
@@ -77,7 +78,7 @@ def cnn(embedding_matrix, dimx=50, dimy=50, nb_filter = 120,
 def cnn_ft(embedding_matrix, dimx=50, dimy=50, dimft=44, nb_filter = 120, 
         embedding_dim = 50,filter_length = (50,4), vocab_size = 8000, depth = 1):
 
-    print 'Model Uses CNN with Features......'
+    print('Model Uses CNN with Features......')
     
     inpx = Input(shape=(dimx,),dtype='int32',name='inpx')   
     inpy = Input(shape=(dimy,),dtype='int32',name='inpy')

--- a/convolution neural tensor network/dl_text/dl.py
+++ b/convolution neural tensor network/dl_text/dl.py
@@ -3,6 +3,7 @@
 ** dl-lab **
 created by :: GauravBh1010tt
 """
+from __future__ import print_function
 
 import re
 import numpy as np
@@ -65,7 +66,7 @@ def process_data(sent_l,sent_r=None,wordVec_model=None,dimx=100,dimy=100,vocab_s
     
     
     freq = FreqDist(chain(*tokenize_sent))
-    print 'found ',len(freq),' unique words'
+    print('found ',len(freq),' unique words')
     vocab = freq.most_common(vocab_size - 1)
     index_to_word = [x[0] for x in vocab]
     index_to_word.append(unk_token)
@@ -127,8 +128,8 @@ def process_data(sent_l,sent_r=None,wordVec_model=None,dimx=100,dimy=100,vocab_s
                 #print j
                 unk.append(j)
                 continue
-        print 'number of unkown words: ',len(unk)
-        print 'some unknown words ',unk[0:5]
+        print('number of unkown words: ',len(unk))
+        print('some unknown words ',unk[0:5])
     
     
     
@@ -158,7 +159,7 @@ def word2vec_embedding_layer(embedding_matrix,train=False):
     return layer
 
 def loadGloveModel(glovefile):
-    print 'Loading Glove File.....'
+    print('Loading Glove File.....')
     f = open(glovefile)
     model = {}
     for line in f:
@@ -166,8 +167,8 @@ def loadGloveModel(glovefile):
         word = splitline[0]
         embedding = np.array([float(val) for val in splitline[1:]])
         model[word] = embedding
-    print 'Loaded Word2Vec GloVe Model.....'
-    print len(model), ' words loaded.....'
+    print('Loaded Word2Vec GloVe Model.....')
+    print(len(model), ' words loaded.....')
     return model
 
 def encode_labels(labels, nclass=5):

--- a/convolution neural tensor network/dl_text/lex_sem_ft.py
+++ b/convolution neural tensor network/dl_text/lex_sem_ft.py
@@ -3,6 +3,7 @@
 ** dl-lab **
 created by :: GauravBh1010tt
 """
+from __future__ import print_function
 
 import pandas as pd
 import numpy as np

--- a/convolution neural tensor network/dl_text/metrics.py
+++ b/convolution neural tensor network/dl_text/metrics.py
@@ -11,6 +11,11 @@ from collections import defaultdict
 import scipy.stats as measures
 import numpy as np
 
+try:
+    xrange          # Python 2
+except NameError:
+    xrange = range  # Python 3
+
 ###################### CALCULATING MRR [RETURNS MRR VALUE] ######################
 
 def mrr(out, th = 10):
@@ -38,10 +43,10 @@ def map(out, th):
       if candidates[i] == "true":
         num_correct += 1
         precisions.append(num_correct/(i+1))
-    
+
     if precisions:
       avg_prec = sum(precisions)/len(precisions)
-    
+
     MAP += avg_prec
   return MAP / num_queries
 
@@ -53,7 +58,7 @@ def list2dict(lst):
 
     for i in range(len(lst)):
         interm[i+1] = lst[i]
-    
+
     for qid in interm:
         interm[qid] = sorted(interm[qid], key = itemgetter(0), reverse = True)
         val = [rel for score, rel in interm[qid]]
@@ -68,11 +73,11 @@ def list2dict(lst):
 def readfile(pred_fname):
     pred = open(pred_fname).readlines()
     pred = [line.split('\t') for line in pred]
-    
+
     ques = []
     ans = []
     i = 1
-    
+
     while i != len(pred):
         if pred[i][0] == pred[i-1][0]:
             ans.append([float(pred[i-1][-2]), pred[i-1][-1][0:-1]])
@@ -83,7 +88,7 @@ def readfile(pred_fname):
         i += 1
     ans.append([float(pred[i-1][-2]), pred[i-1][-1][0:-1]])
     ques.append(ans)
-    
+
     return ques
 
 ###################### MAP AND MRR FUNCTION [RETURNS MAP AND MRR VALUES] ######################
@@ -94,17 +99,17 @@ def map_mrr(pred_fname, th = 10):
     return map(dic,th), mrr(dic,th)
 
 def eval_metric(lrmodel, X_test_l, X_test_r, res_fname,pred_fname,use_softmax=True, feat_test=None):
-    
+
     if feat_test!=None:
         pred = lrmodel.predict([X_test_l, X_test_r, feat_test])[:,1]
     else:
         pred = lrmodel.predict([X_test_l, X_test_r])[:,1]
 
     ################### SAVING PREDICTIONS ###################
-    
+
     f1 = open(res_fname, 'r').readlines()
     f2 = open(pred_fname,'w')
-    
+
     for j,line in enumerate(f1):
         line = line.split('\t')
         #val = [line[0]+'\t',line[1]+'\t',line[2]+'\t',str(pred[j][0])+'\t',line[-1]]
@@ -113,13 +118,13 @@ def eval_metric(lrmodel, X_test_l, X_test_r, res_fname,pred_fname,use_softmax=Tr
         else:
             val = [line[0]+'\t',line[1]+'\t',line[2]+'\t',str(pred[j][0])+'\t',line[-1]]
         f2.writelines(val)
-    
+
     f2.close()
-    
+
     ################### PRINTING AND SAVING MAP-MRR VALUES ###################
-    
+
     map_val, mrr_val = map_mrr(pred_fname)
-    
+
     #print 'MAP:', map_val
     #print 'MRR:', mrr_val
     return map_val, mrr_val
@@ -133,5 +138,5 @@ def eval_sick(model,X_test_l,X_test_r,test_score):
     sp_coef = measures.spearmanr(pred,test_score)[0]
     per_coef = measures.pearsonr(pred,test_score)[0]
     mse_coef = np.mean(np.square(pred-test_score))
-    
+
     return sp_coef, per_coef, mse_coef

--- a/convolution neural tensor network/main.py
+++ b/convolution neural tensor network/main.py
@@ -3,6 +3,7 @@
 ** dl-lab **
 created by :: GauravBh1010tt
 """
+from __future__ import print_function
 
 import model_cntn as model
 import trec_utils as trec
@@ -14,7 +15,7 @@ glove_fname = 'D:/workspace/NLP/data/Glove/glove.6B.50d.txt'
 ################### DEFINING MODEL ###################
 
 lrmodel = model.cntn
-model_name = lrmodel.func_name
+model_name = lrmodel.__name__
 
 ################### DEFINING HYPERPARAMETERS ###################
 
@@ -43,9 +44,9 @@ X_train_l,X_test_l,X_dev_l,X_train_r,X_test_r,X_dev_r = trec.prepare_train_test(
 lrmodel = lrmodel(embedding_matrix, dimx=dimx, dimy=dimy, nb_filter = nb_filter, embedding_dim = embedding_dim,
                   num_slices = num_tensor_slices, filter_length = filter_length, vocab_size = vocab_size, depth = depth)
     
-print '\n', model_name,'model built \n'
+print('\n', model_name,'model built \n')
 lrmodel.fit([X_train_l, X_train_r],label_train,batch_size=batch_size,nb_epoch=nb_epoch,verbose=2)
 map_val, mrr_val = eval_metric(lrmodel, X_test_l, X_test_r, res_fname, pred_fname)
 
     
-print 'MAP : ',map_val,' MRR : ',mrr_val
+print('MAP : ',map_val,' MRR : ',mrr_val)

--- a/convolution neural tensor network/model_cntn.py
+++ b/convolution neural tensor network/model_cntn.py
@@ -3,6 +3,7 @@
 ** dl-lab **
 created by :: GauravBh1010tt
 """
+from __future__ import print_function
 
 from keras import backend as K
 from keras.models import Model
@@ -19,7 +20,7 @@ from dl_layers.layers import Similarity, ntn
 def cntn(embedding_matrix, dimx=50, dimy=50, nb_filter = 120, num_slices = 3,
         embedding_dim = 50,filter_length = (50,4), vocab_size = 8000, depth = 1):
 
-    print 'Model Uses CNTN ......'
+    print('Model Uses CNTN ......')
     
     inpx = Input(shape=(dimx,),dtype='int32',name='inpx')   
     inpy = Input(shape=(dimy,),dtype='int32',name='inpy')

--- a/corrMCNN/CorrMCNN_Arch2.py
+++ b/corrMCNN/CorrMCNN_Arch2.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 #CorrMCNN: Gaurav Bhatt and Piyush Jha
 # had to degrade numpy to 1.11.0 as 1.13.0 doesn't support float index type in arrays
 
@@ -283,7 +284,7 @@ def trainModel(model,data_left,data_right,loss_type,nb_epoch,batch_size):
     label = np.load('data_label.npy')
     X_train_l, X_test_l, X_train_r, X_test_r,y_train,y_test = split(data_l,data_r,label,ratio=0.01)
     print ('data split')
-    print ('L_Type: l2+l3-L4   h_dim:',hdim,'   hdim_deep',hdim_deep,'  lamda:',lamda)
+    print(('L_Type: l2+l3-L4   h_dim:',hdim,'   hdim_deep',hdim_deep,'  lamda:',lamda))
     model.fit([X_train_l,X_train_r], [X_train_r,X_train_l,X_train_l,X_train_r,
               np.zeros((X_train_l.shape[0],h_loss)),
              np.zeros((X_train_l.shape[0],hdim_deep)),np.zeros((X_train_l.shape[0],hdim_deep2))],

--- a/corrMCNN/XRMB_CNN_17.06.v2.py
+++ b/corrMCNN/XRMB_CNN_17.06.v2.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 #Note
 
 #CNN used

--- a/fake news challenge (FNC-1)/cnn_stop.py
+++ b/fake news challenge (FNC-1)/cnn_stop.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import print_function
 import utility
 import warnings
 import numpy as np
@@ -308,5 +309,5 @@ for i,j in enumerate(predictions):
 from sklearn.metrics import accuracy_score
 from utils.score import report_score
 score = accuracy_score(string_predicted, test_labels)
-print("Accuracy on test dataset: ",score)
+print(("Accuracy on test dataset: ",score))
 report_score(string_predicted, test_labels)

--- a/fake news challenge (FNC-1)/eval_fnc.py
+++ b/fake news challenge (FNC-1)/eval_fnc.py
@@ -1,6 +1,7 @@
 '''
 Evaluation code for the SICK dataset (SemEval 2014 Task 1)
 '''
+from __future__ import print_function
 import numpy as np
 import os.path
 from util import *
@@ -34,13 +35,13 @@ def split(train_l,train_r,label,ratio):
         tr_l.append(train_l[a])
         tr_r.append(train_r[a])
         l_tr.append(label[a])
-    print 'splitting - validation samples ',test_samples
+    print('splitting - validation samples ',test_samples)
     for i in range(total):
         if i not in dat:
             tst_l.append(train_l[i])
             tst_r.append(train_r[i])
             l_tst.append(label[i])
-    print 'splitting - train samples ',len(dat)        
+    print('splitting - train samples ',len(dat))        
     tr_l = np.array(tr_l)
     tr_r = np.array(tr_r)
     tst_l = np.array(tst_l)
@@ -154,7 +155,7 @@ def load_dataset(file_trhead, file_trbody, file_tshead, file_tsbody):
     test_new_rdb = []
 
     word_limit = 250    
-    print 'removing stop words and using', word_limit,'words limit .....'
+    print('removing stop words and using', word_limit,'words limit .....')
     
     for i in train_rdb:
         temp=[]
@@ -188,7 +189,7 @@ def evaluate(encoder=None, seed=1234, evaltest=False, loc='./data/'):
     """
     Run experiment
     """
-    print 'Preparing data for fnc...'
+    print('Preparing data for fnc...')
     
     #train, dev, test, scores = load_data(loc)
     #train[0], train[1], scores[0] = shuffle(train[0], train[1], scores[0], random_state=seed)
@@ -207,13 +208,13 @@ def evaluate(encoder=None, seed=1234, evaltest=False, loc='./data/'):
     #train_b = big_mat
     #train_h, dev_h, train_b, dev_b, score_train, dev_score = split(np.array(train_h), train_b, score_train, 0.2)
  
-    print 'loading training skipthoughts...'
+    print('loading training skipthoughts...')
     #trainA = encoder.encode(train_h, verbose=False, use_eos=True)
     #trainB = encoder.encode(train_b, verbose=False, use_eos=True)
     trainA = train_h
     trainB = train_b
     
-    print 'Computing development skipthoughts...'
+    print('Computing development skipthoughts...')
     #devA = encoder.encode(dev_h, verbose=False, use_eos=True)
     #devB = encoder.encode(dev_b, verbose=False, use_eos=True)
 #    devA = dev_h
@@ -222,11 +223,11 @@ def evaluate(encoder=None, seed=1234, evaltest=False, loc='./data/'):
     devB = test_b
     dev_score = score_test
 
-    print 'Computing feature combinations...'
+    print('Computing feature combinations...')
     trainF = np.c_[np.abs(trainA - trainB), trainA * trainB]
     devF = np.c_[np.abs(devA - devB), devA * devB]
 
-    print 'Encoding labels...'
+    print('Encoding labels...')
     #trainY = encode_labels(train_labels)
     #devY = encode_labels(holdout_labels)
     trainY = to_categorical(score_train, 4)
@@ -237,18 +238,18 @@ def evaluate(encoder=None, seed=1234, evaltest=False, loc='./data/'):
 
     train_tfidf, test_tfidf = generate_tfidf()
     
-    print 'Compiling model...'
+    print('Compiling model...')
     lrmodel = prepare_model(ninputs=trainF.shape[1],n_feats=train_Fx.shape[1],n_tfidf=train_tfidf.shape[1])
 
-    print 'Training...'
+    print('Training...')
     bestlrmodel = train_model(lrmodel, trainF, trainY, devF, devY, dev_score, train_Fx, test_Fx, train_tfidf, test_tfidf)
     
     if evaltest:
-        print 'Loading test skipthoughts...'
+        print('Loading test skipthoughts...')
         testA = test_h
         testB = test_b
 
-        print 'Computing feature combinations...'
+        print('Computing feature combinations...')
         testF = np.c_[np.abs(testA - testB), testA * testB]
         
         yhat = bestlrmodel.predict(testF, verbose=2)
@@ -276,7 +277,7 @@ def evaluate(encoder=None, seed=1234, evaltest=False, loc='./data/'):
                 
         report_score(test_stances,string_predicted)
         score = accuracy_score(score_test, yhat)
-        print 'accuracy is ..',score
+        print('accuracy is ..',score)
         #print 'Evaluating...'
 
 
@@ -475,19 +476,19 @@ def train_model(lrmodel, X, Y, devX, devY, devscores, feat_train, feat_dev, trai
                 test_stances.append('discuss')
             if j == 1:
                 test_stances.append('disagree')
-        print 'using new limit value....'
+        print('using new limit value....')
         #score = accuracy_score(devscores, yhat)
         score = report_score(test_stances,string_predicted,val=True)
         #return lrmodel
     
         if score > best:
-            print score
+            print(score)
             best = score
             bestlrmodel = prepare_model(ninputs=X.shape[1],n_feats=feat_train.shape[1],n_tfidf=train_tfidf.shape[1])
             bestlrmodel.set_weights(lrmodel.get_weights())
         else:
             done = True
-            print '***** best model obtained with score',best,'******'
+            print('***** best model obtained with score',best,'******')
 
     yhat = bestlrmodel.predict([devX, feat_dev, test_tfidf], verbose=2)
     yhat = [i.argmax()for i in yhat]

--- a/fake news challenge (FNC-1)/eval_sick.py
+++ b/fake news challenge (FNC-1)/eval_sick.py
@@ -1,6 +1,7 @@
 '''
 Evaluation code for the SICK dataset (SemEval 2014 Task 1)
 '''
+from __future__ import print_function
 
 import os
 import numpy as np
@@ -35,26 +36,26 @@ def evaluate(encoder, seed=1234, evaltest=False, loc='F:\\workspace\\project\\Si
     """
     Run experiment
     """
-    print 'Preparing data...'
+    print('Preparing data...')
     train, dev, test, scores = load_data(loc)
     train[0], train[1], scores[0] = shuffle(train[0], train[1], scores[0], random_state=seed)
     
-    print 'Computing training skipthoughts...'
+    print('Computing training skipthoughts...')
     trainA = encoder.encode(train[0], verbose=False, use_eos=True)
     trainB = encoder.encode(train[1], verbose=False, use_eos=True)
     
-    print 'Computing development skipthoughts...'
+    print('Computing development skipthoughts...')
     devA = encoder.encode(dev[0], verbose=False, use_eos=True)
     devB = encoder.encode(dev[1], verbose=False, use_eos=True)
 
-    print 'Computing test skipthoughts...'
+    print('Computing test skipthoughts...')
     testA = encoder.encode(test[0], verbose=False, use_eos=True)
     testB = encoder.encode(test[1], verbose=False, use_eos=True)
 
-    print 'Computing feature combinations...'
+    print('Computing feature combinations...')
     testF = np.c_[np.abs(testA - testB), testA * testB]
 
-    print 'Computing feature combinations...'
+    print('Computing feature combinations...')
     trainF = np.c_[np.abs(trainA - trainB), trainA * trainB]
     #devF = np.c_[np.abs(devA - devB), devA * devB]
     
@@ -63,7 +64,7 @@ def evaluate(encoder, seed=1234, evaltest=False, loc='F:\\workspace\\project\\Si
     #trainF = np.c_[trainA, trainB]
     #devF = np.c_[devA, devB]
     
-    print 'Computing external feature ...'
+    print('Computing external feature ...')
     feat_train = np.load('feat_train.npy')
     feat_test = np.load('feat_test.npy')
     
@@ -83,7 +84,7 @@ def evaluate(encoder, seed=1234, evaltest=False, loc='F:\\workspace\\project\\Si
     
     feat_dev = feat1_test
     
-    print 'Encoding labels...'
+    print('Encoding labels...')
     
     trainY = encode_labels(scores[0])
     #devY = encode_labels(scores[1])
@@ -96,25 +97,25 @@ def evaluate(encoder, seed=1234, evaltest=False, loc='F:\\workspace\\project\\Si
     #trainY = to_categorical(np.round(scores[0]),5)
     #devY = to_categorical(np.round(scores[1]),5)
 
-    print 'Compiling model...'
+    print('Compiling model...')
     lrmodel = prepare_model(ninputs=trainF.shape[1],n_feats=feat1_train.shape[1])
 
-    print 'Training...'
+    print('Training...')
     bestlrmodel = train_model(lrmodel, trainF, trainY, devF, devY, scores[2], feat1_train, feat_dev)
     #bestlrmodel = train_model(lrmodel, trainF, trainY, devF, devY, scores[1])
 
     if evaltest:
 
-        print 'Evaluating...'
+        print('Evaluating...')
         r = np.arange(1,6)
         yhat = np.dot(bestlrmodel.predict([testF,feat1_test], verbose=2), r)
         #yhat = np.dot(bestlrmodel.predict_proba(testF, verbose=2), r)
         pr = pearsonr(yhat, scores[2])[0]
         sr = spearmanr(yhat, scores[2])[0]
         se = mse(yhat, scores[2])
-        print 'Test Pearson: ' + str(pr)
-        print 'Test Spearman: ' + str(sr)
-        print 'Test MSE: ' + str(se)
+        print('Test Pearson: ' + str(pr))
+        print('Test Spearman: ' + str(sr))
+        print('Test MSE: ' + str(se))
 
         return yhat
 
@@ -194,7 +195,7 @@ def train_model(lrmodel, X, Y, devX, devY, devscores, feat_train, feat_dev):
         score = pearsonr(yhat, devscores)[0]
         
         if score > best:
-            print score,num
+            print(score,num)
             best = score
             #print type(X)
             bestlrmodel = prepare_model(ninputs=X.shape[1],n_feats=feat_train.shape[1])
@@ -215,7 +216,7 @@ def train_model(lrmodel, X, Y, devX, devY, devscores, feat_train, feat_dev):
     yhat = np.dot(bestlrmodel.predict([devX,feat_dev], verbose=2), r)
     #yhat = np.dot(bestlrmodel.predict_proba(devX, verbose=2), r)
     score = pearsonr(yhat, devscores)[0]
-    print 'Dev Pearson: ' + str(score)
+    print('Dev Pearson: ' + str(score))
     return bestlrmodel
     
 

--- a/fake news challenge (FNC-1)/fnc_kfold.py
+++ b/fake news challenge (FNC-1)/fnc_kfold.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import sys
 import numpy as np
 

--- a/fake news challenge (FNC-1)/fnc_libs.py
+++ b/fake news challenge (FNC-1)/fnc_libs.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import print_function
 import numpy as np
 import pandas as pd
 from keras.utils.np_utils import to_categorical
@@ -261,8 +262,8 @@ def load_data(file_head,file_body):
     body = pd.read_csv(file_body)
     head_array = head.values
     body_array = body.values                    ##########
-    print('number of headlines : ',len(head_array))
-    print('number of news body : ',len(body_array))
+    print(('number of headlines : ',len(head_array)))
+    print(('number of news body : ',len(body_array)))
     labels = head_array[:,2]
     body_id = head_array[:,1]
     dataset_headLines = head_array[:,0]         ##########

--- a/fake news challenge (FNC-1)/lstm_new.py
+++ b/fake news challenge (FNC-1)/lstm_new.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 # -*- coding: utf-8 -*-
+from __future__ import print_function
 from fnc_libs import *
 
 d = DataSet()

--- a/fake news challenge (FNC-1)/p3_cnn.py
+++ b/fake news challenge (FNC-1)/p3_cnn.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import print_function
 import numpy as np
 import pandas as pd
 from keras.utils.np_utils import to_categorical

--- a/fake news challenge (FNC-1)/p3_lstm.py
+++ b/fake news challenge (FNC-1)/p3_lstm.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 # -*- coding: utf-8 -*-
+from __future__ import print_function
 import numpy as np
 import pandas as pd
 from keras.utils.np_utils import to_categorical

--- a/fake news challenge (FNC-1)/run_sick.py
+++ b/fake news challenge (FNC-1)/run_sick.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
-print 'started....'
+from __future__ import print_function
+print('started....')
 #import skipthoughts
 #import eval_sick
 import eval_fnc
 import warnings
+from importlib import reload
 
 warnings.simplefilter("ignore")
 
@@ -17,4 +19,3 @@ i=4997
 
 reload(eval_fnc)
 eval_fnc.evaluate(encoder=None, evaltest=False)
-

--- a/fake news challenge (FNC-1)/ucl_fnc.py
+++ b/fake news challenge (FNC-1)/ucl_fnc.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import print_function
 from fnc_libs import *
 from keras import optimizers as op
 from util import *

--- a/fake news challenge (FNC-1)/utility.py
+++ b/fake news challenge (FNC-1)/utility.py
@@ -5,6 +5,7 @@ Created on Tue Mar 07 11:48:18 2017
 
 @author: Gaurav
 """
+from __future__ import print_function
 
 import math
 import random
@@ -85,7 +86,7 @@ def sum_corr(view1,view2,flag=''):
     corr = 0
     for i,j in zip(view1,view2):
         corr += measures.pearsonr(i,j)[0]
-    print('avg sum corr ::',flag,'::',corr/len(view1))
+    print(('avg sum corr ::',flag,'::',corr/len(view1)))
 
 def cal_sim(model,ind1,ind2=1999):
     view1 = np.load("test_v1.npy")[0:ind1]
@@ -119,7 +120,7 @@ def cal_sim(model,ind1,ind2=1999):
         print(AP)
         MAP+=AP
     #print 'accuracy  :- ',float(count)*100/ind1,'%'
-    print('MAP is : ',MAP/ind1)
+    print(('MAP is : ',MAP/ind1))
 
 def cos_sim(ind1,ind2=1999):
     view1 = np.load("test_v1.npy")[0:ind1]
@@ -144,7 +145,7 @@ def cos_sim(ind1,ind2=1999):
         print(t)
         print(AP)
         MAP+=AP
-    print('MAP is : ',MAP/ind1)
+    print(('MAP is : ',MAP/ind1))
 
 class sample:
     def __init__(self):
@@ -164,7 +165,7 @@ class sample:
                                          pattern = '\w+|$[\d\.]+|\S+') for x in sentence]
                         
         freq = nltk.FreqDist(itertools.chain(*self.tokenize_sent))
-        print('found ',len(freq),' unique words')
+        print(('found ',len(freq),' unique words'))
         vocab = freq.most_common(vocab_size - 1)
         self.index_to_word = [x[0] for x in vocab]
         self.index_to_word.append(unk_token)
@@ -233,6 +234,6 @@ class sample:
                 
                 unk.append(j)
                 continue
-        print('number of unkown words: ',len(unk))
-        print('some unknown words ',unk[0:5])
+        print(('number of unkown words: ',len(unk)))
+        print(('some unknown words ',unk[0:5]))
         return X_data,y_data,embedding_matrix

--- a/fake news challenge (FNC-1)/utils/dataset.py
+++ b/fake news challenge (FNC-1)/utils/dataset.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from csv import DictReader
 
 

--- a/fake news challenge (FNC-1)/utils/score.py
+++ b/fake news challenge (FNC-1)/utils/score.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 #Adapted from https://github.com/FakeNewsChallenge/fnc-1/blob/master/scorer.py
 #Original credit - @bgalbraith
 

--- a/fake news challenge (FNC-1)/utils/system.py
+++ b/fake news challenge (FNC-1)/utils/system.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import sys
 import os
 import re

--- a/neural tensor network/ntn_model.py
+++ b/neural tensor network/ntn_model.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import print_function
 import glob
 import ntn_input
 from ntn import *


### PR DESCRIPTION
Some minimal, "safe" changes to make the code syntax compatible with both Python 2 and Python 3.

* Run futurize --stage1 http://python-future.org/futurize_cheatsheet.html
* Adjust adjust some lambda and tuple expressions to be compatible with Python 3.

Ready for review. Python 3 syntax compatibility does not mean that the port is complete.